### PR TITLE
avoid running workflows twice

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,8 +1,10 @@
 name: Rust
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - main
+  pull_request: {}
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
This more specific configuration sets:

- push with branch filtering: Only pushes to the main branch will trigger the workflow, not pushes to other branches.
- pull_request: {} is shorthand to trigger on any pull request event

With this we avoid running workflows twice on pull requests.