### PR TITLE
refactor!: replace `once_cell::sync::Lazy` by the `std` implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ edition = "2021"
 [dependencies]
 jiff = "0.1"
 nom = "~7"
-once_cell = "1.10"
 serde = {version = "1.0.164", optional = true }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,11 @@ Licensed under either of
 - MIT license ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/licenses/MIT)
   at your option.
 
-### Contribution
+## Minimum supported Rust version (MSRV)
+
+This crate requires Rust 1.80.0 or newer.
+
+## Contribution
 
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you shall be dual licensed as above, without any

--- a/src/time_unit/days_of_month.rs
+++ b/src/time_unit/days_of_month.rs
@@ -1,13 +1,11 @@
-use std::borrow::Cow;
-
-use once_cell::sync::Lazy;
+use std::{borrow::Cow, sync::LazyLock};
 
 use crate::{
     ordinal::{Ordinal, OrdinalSet},
     time_unit::TimeUnitField,
 };
 
-static ALL: Lazy<OrdinalSet> = Lazy::new(DaysOfMonth::supported_ordinals);
+static ALL: LazyLock<OrdinalSet> = LazyLock::new(DaysOfMonth::supported_ordinals);
 
 #[derive(Clone, Debug, Eq)]
 pub struct DaysOfMonth {

--- a/src/time_unit/days_of_week.rs
+++ b/src/time_unit/days_of_week.rs
@@ -1,6 +1,4 @@
-use std::borrow::Cow;
-
-use once_cell::sync::Lazy;
+use std::{borrow::Cow, sync::LazyLock};
 
 use crate::{
     error::*,
@@ -8,7 +6,7 @@ use crate::{
     time_unit::TimeUnitField,
 };
 
-static ALL: Lazy<OrdinalSet> = Lazy::new(DaysOfWeek::supported_ordinals);
+static ALL: LazyLock<OrdinalSet> = LazyLock::new(DaysOfWeek::supported_ordinals);
 
 #[derive(Clone, Debug, Eq)]
 pub struct DaysOfWeek {

--- a/src/time_unit/hours.rs
+++ b/src/time_unit/hours.rs
@@ -1,13 +1,11 @@
-use std::borrow::Cow;
-
-use once_cell::sync::Lazy;
+use std::{borrow::Cow, sync::LazyLock};
 
 use crate::{
     ordinal::{Ordinal, OrdinalSet},
     time_unit::TimeUnitField,
 };
 
-static ALL: Lazy<OrdinalSet> = Lazy::new(Hours::supported_ordinals);
+static ALL: LazyLock<OrdinalSet> = LazyLock::new(Hours::supported_ordinals);
 
 #[derive(Clone, Debug, Eq)]
 pub struct Hours {

--- a/src/time_unit/minutes.rs
+++ b/src/time_unit/minutes.rs
@@ -1,13 +1,11 @@
-use std::borrow::Cow;
-
-use once_cell::sync::Lazy;
+use std::{borrow::Cow, sync::LazyLock};
 
 use crate::{
     ordinal::{Ordinal, OrdinalSet},
     time_unit::TimeUnitField,
 };
 
-static ALL: Lazy<OrdinalSet> = Lazy::new(Minutes::supported_ordinals);
+static ALL: LazyLock<OrdinalSet> = LazyLock::new(Minutes::supported_ordinals);
 
 #[derive(Clone, Debug, Eq)]
 pub struct Minutes {

--- a/src/time_unit/months.rs
+++ b/src/time_unit/months.rs
@@ -1,6 +1,4 @@
-use std::borrow::Cow;
-
-use once_cell::sync::Lazy;
+use std::{borrow::Cow, sync::LazyLock};
 
 use crate::{
     error::*,
@@ -8,7 +6,7 @@ use crate::{
     time_unit::TimeUnitField,
 };
 
-static ALL: Lazy<OrdinalSet> = Lazy::new(Months::supported_ordinals);
+static ALL: LazyLock<OrdinalSet> = LazyLock::new(Months::supported_ordinals);
 
 #[derive(Clone, Debug, Eq)]
 pub struct Months {

--- a/src/time_unit/seconds.rs
+++ b/src/time_unit/seconds.rs
@@ -1,13 +1,11 @@
-use std::borrow::Cow;
-
-use once_cell::sync::Lazy;
+use std::{borrow::Cow, sync::LazyLock};
 
 use crate::{
     ordinal::{Ordinal, OrdinalSet},
     time_unit::TimeUnitField,
 };
 
-static ALL: Lazy<OrdinalSet> = Lazy::new(Seconds::supported_ordinals);
+static ALL: LazyLock<OrdinalSet> = LazyLock::new(Seconds::supported_ordinals);
 
 #[derive(Clone, Debug, Eq)]
 pub struct Seconds {

--- a/src/time_unit/years.rs
+++ b/src/time_unit/years.rs
@@ -1,13 +1,11 @@
-use std::borrow::Cow;
-
-use once_cell::sync::Lazy;
+use std::{borrow::Cow, sync::LazyLock};
 
 use crate::{
     ordinal::{Ordinal, OrdinalSet},
     time_unit::TimeUnitField,
 };
 
-static ALL: Lazy<OrdinalSet> = Lazy::new(Years::supported_ordinals);
+static ALL: LazyLock<OrdinalSet> = LazyLock::new(Years::supported_ordinals);
 
 #[derive(Clone, Debug, Eq)]
 pub struct Years {


### PR DESCRIPTION
The implementation of `std::sync::LazyLock`
functions as a drop-in replacement for
`once_cell::sync::Lazy` - allowing us to shed
a dependency.

`std::sync::LazyLock` was introduced
with Rust 1.80.0.

Related to #7

BREAKING CHANGE: This crate now requires Rust 1.80.0 or higher.