### PR TITLE
docs: document shared authorship

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "jiff-cron"
 version = "0.1.1"
 authors = [
+    "Leonie Philine Bitto <bitto@posteo.de>",
     "Max Countryman <hello@maxcountryman.com>",
     "Zack Slayton <zack.slayton@gmail.com>",
 ]


### PR DESCRIPTION
The current diff adheres to alphabetical order.

However, I would like give credit to your fork initiative. The same is true for giving credit to the original author. Shall we flip the list upside down? Does it matter at all?