### PR TITLE
feat: re-export `jiff`, fix up docs and doctests

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 A cron expression parser built with `jiff`.
 
 ```rust
-use jiff_cron::Schedule;
-use jiff::tz::TimeZone;
+use jiff_cron::{jiff::tz::TimeZone, Schedule};
 use std::str::FromStr;
 
 fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,11 +5,10 @@
 //!
 //! # Example
 //!
-//! ```
+//! ```rust
 //! use std::str::FromStr;
 //!
-//! use jiff::tz::TimeZone;
-//! use jiff_cron::Schedule;
+//! use jiff_cron::{jiff::tz::TimeZone, Schedule};
 //!
 //! fn main() {
 //!     //               sec  min   hour   day of month   month   day of week   year
@@ -45,6 +44,8 @@ mod queries;
 mod schedule;
 mod specifier;
 mod time_unit;
+
+pub use jiff;
 
 pub use crate::{
     schedule::{OwnedScheduleIterator, Schedule, ScheduleIterator},

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -256,8 +256,8 @@ impl Schedule {
         None
     }
 
-    /// Provides an iterator which will return each DateTime that matches the
-    /// schedule starting with the current time if applicable.
+    /// Provides an iterator which will return each [`jiff::Zoned`] that matches
+    /// the schedule starting with the current time if applicable.
     pub fn upcoming(&self, timezone: TimeZone) -> ScheduleIterator<'_> {
         let after = Zoned::now().with_time_zone(timezone);
         self.after(&after)


### PR DESCRIPTION
Since `jiff` types are part of our public API,
they should be publicly re-exported.

This changeset also:

- marks an existing code example as doctest
- adjusts code examples to use the re-export
- references the yielded `jiff::Zoned` rustdoc

Resolves #8