### PR TITLE
fix(deps): declare broader dependency versions, insert status badge

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,16 +16,16 @@ edition = "2021"
 
 [dependencies]
 jiff = "0.1"
-nom = "~7"
-serde = {version = "1.0.164", optional = true }
+nom = "7"
+serde = {version = "1", optional = true }
 
 [dev-dependencies]
-serde_test = "1.0.164"
+serde_test = "1"
 
 # Dev-dependency for feature "serde".
 # Optional dev-dependencies are not supported yet.
 # Cargo feature request is available at https://github.com/rust-lang/cargo/issues/1596
-postcard = { version = "1.0.10", default-features = false, features = ["use-std"] }
+postcard = { version = "1", default-features = false, features = ["use-std"] }
 
 [features]
 serde = ["dep:serde"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# jiff-cron [![Rust](https://github.com/maxcountryman/jiff-cron/workflows/Rust/badge.svg)](https://github.com/maxcountryman/jiff-cron/actions) [![](https://img.shields.io/crates/v/jiff-cron.svg)](https://crates.io/crates/jiff-cron) [![](https://docs.rs/jiff-cron/badge.svg)](https://docs.rs/jiff-cron)
+# jiff-cron [![Rust](https://github.com/maxcountryman/jiff-cron/workflows/Rust/badge.svg)](https://github.com/maxcountryman/jiff-cron/actions) [![dependency status](https://deps.rs/repo/github/jiff-cron/jiff-cron/status.svg)](https://deps.rs/repo/github/jiff-cron/jiff-cron) [![](https://img.shields.io/crates/v/jiff-cron.svg)](https://crates.io/crates/jiff-cron) [![](https://docs.rs/jiff-cron/badge.svg)](https://docs.rs/jiff-cron)
 
 A cron expression parser built with `jiff`.
 


### PR DESCRIPTION
## [fix(deps): declare broader dependency versions](https://github.com/jiff-cron/jiff-cron/commit/a6b999c9d03287e89bb38bb162bcabc4128f4345)

Reduce the dependency version precision to
only the detail we need (semver-breaking).

Should we integrate Renovate for automated updates,
then this reduces update noise drastically
(depending, of course, on renovate configuration).

Resolves https://github.com/jiff-cron/jiff-cron/issues/18

## [feat(docs): insert dependency status badge](https://github.com/jiff-cron/jiff-cron/commit/36398ec995a8ed97940ed8592956a3bc3c469c99)

Related to https://github.com/jiff-cron/jiff-cron/issues/18