### PR TITLE
inline format arguments

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -16,7 +16,7 @@ pub enum ErrorKind {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.kind {
-            ErrorKind::Expression(ref expr) => write!(f, "Invalid expression: {}", expr),
+            ErrorKind::Expression(ref expr) => write!(f, "Invalid expression: {expr}"),
         }
     }
 }

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -681,11 +681,11 @@ mod test {
         assert!(next.is_some());
 
         let next2 = schedule.next_after(next.as_ref().unwrap());
-        println!("NEXT2 AFTER for {} {:?}", expression, next2);
+        println!("NEXT2 AFTER for {expression} {next2:?}");
         assert!(next2.is_some());
 
         let prev = schedule.prev_from(next2.as_ref().unwrap());
-        println!("PREV FROM for {} {:?}", expression, prev);
+        println!("PREV FROM for {expression} {prev:?}");
         assert!(prev.is_some());
         assert_eq!(prev, next);
 
@@ -695,7 +695,7 @@ mod test {
                 .map(|next2| next2.saturating_add(SignedDuration::from_millis(100)))
                 .unwrap(),
         );
-        println!("PREV2 FROM for {} {:?}", expression, prev2);
+        println!("PREV2 FROM for {expression} {prev2:?}");
         assert!(prev2.is_some());
         assert_eq!(prev2, next2);
     }
@@ -713,7 +713,7 @@ mod test {
         let expression = "0 5 17 1 6 ? 2022".to_string();
         let schedule = Schedule::from_str(&expression).unwrap();
         let next = schedule.next_after(&starting_point);
-        println!("NEXT AFTER for {} {:?}", expression, next);
+        println!("NEXT AFTER for {expression} {next:?}");
         assert!(next.is_some());
     }
 
@@ -723,7 +723,7 @@ mod test {
         let schedule = Schedule::from_str(expression).unwrap();
         let utc_now = Zoned::now().with_time_zone(TimeZone::UTC);
         let prev = schedule.prev_from(&utc_now);
-        println!("PREV FROM for {} {:?}", expression, prev);
+        println!("PREV FROM for {expression} {prev:?}");
         assert!(prev.is_some());
     }
 
@@ -733,7 +733,7 @@ mod test {
         let schedule = Schedule::from_str(expression).unwrap();
         let utc_now = Zoned::now().with_time_zone(TimeZone::UTC);
         let next = schedule.next_after(&utc_now);
-        println!("NEXT AFTER for {} {:?}", expression, next);
+        println!("NEXT AFTER for {expression} {next:?}");
         assert!(next.is_some());
     }
 
@@ -748,9 +748,9 @@ mod test {
         assert!(next2.is_some());
         let next3 = upcoming.next();
         assert!(next3.is_some());
-        println!("Upcoming 1 for {} {:?}", expression, next1);
-        println!("Upcoming 2 for {} {:?}", expression, next2);
-        println!("Upcoming 3 for {} {:?}", expression, next3);
+        println!("Upcoming 1 for {expression} {next1:?}");
+        println!("Upcoming 2 for {expression} {next2:?}");
+        println!("Upcoming 3 for {expression} {next3:?}");
     }
 
     #[test]
@@ -764,9 +764,9 @@ mod test {
         assert!(next2.is_some());
         let next3 = upcoming.next();
         assert!(next3.is_some());
-        println!("Upcoming 1 for {} {:?}", expression, next1);
-        println!("Upcoming 2 for {} {:?}", expression, next2);
-        println!("Upcoming 3 for {} {:?}", expression, next3);
+        println!("Upcoming 1 for {expression} {next1:?}");
+        println!("Upcoming 2 for {expression} {next2:?}");
+        println!("Upcoming 3 for {expression} {next3:?}");
     }
 
     #[test]
@@ -780,9 +780,9 @@ mod test {
         assert!(prev2.is_some());
         let prev3 = upcoming.next();
         assert!(prev3.is_some());
-        println!("Prev Upcoming 1 for {} {:?}", expression, prev1);
-        println!("Prev Upcoming 2 for {} {:?}", expression, prev2);
-        println!("Prev Upcoming 3 for {} {:?}", expression, prev3);
+        println!("Prev Upcoming 1 for {expression} {prev1:?}");
+        println!("Prev Upcoming 2 for {expression} {prev2:?}");
+        println!("Prev Upcoming 3 for {expression} {prev3:?}");
     }
 
     #[test]
@@ -796,9 +796,9 @@ mod test {
         assert!(prev2.is_some());
         let prev3 = upcoming.next();
         assert!(prev3.is_some());
-        println!("Prev Upcoming 1 for {} {:?}", expression, prev1);
-        println!("Prev Upcoming 2 for {} {:?}", expression, prev2);
-        println!("Prev Upcoming 3 for {} {:?}", expression, prev3);
+        println!("Prev Upcoming 1 for {expression} {prev1:?}");
+        println!("Prev Upcoming 2 for {expression} {prev2:?}");
+        println!("Prev Upcoming 3 for {expression} {prev3:?}");
     }
 
     #[test]
@@ -812,9 +812,9 @@ mod test {
         assert!(next2.is_some());
         let next3 = upcoming.next();
         assert!(next3.is_some());
-        println!("Upcoming 1 for {} {:?}", expression, next1);
-        println!("Upcoming 2 for {} {:?}", expression, next2);
-        println!("Upcoming 3 for {} {:?}", expression, next3);
+        println!("Upcoming 1 for {expression} {next1:?}");
+        println!("Upcoming 2 for {expression} {next2:?}");
+        println!("Upcoming 3 for {expression} {next3:?}");
     }
 
     #[test]
@@ -831,7 +831,7 @@ mod test {
         let expression = "@monthly";
         let schedule = Schedule::from_str(expression).unwrap();
         let mut result = String::new();
-        write!(result, "{}", schedule).unwrap();
+        write!(result, "{schedule}").unwrap();
         assert_eq!(expression, result);
     }
 

--- a/src/time_unit/days_of_week.rs
+++ b/src/time_unit/days_of_week.rs
@@ -40,8 +40,7 @@ impl TimeUnitField for DaysOfWeek {
             "sat" | "saturday" => 7,
             _ => {
                 return Err(ErrorKind::Expression(format!(
-                    "'{}' is not a valid day of the week.",
-                    name
+                    "'{name}' is not a valid day of the week."
                 ))
                 .into())
             }

--- a/src/time_unit/months.rs
+++ b/src/time_unit/months.rs
@@ -45,7 +45,7 @@ impl TimeUnitField for Months {
             "dec" | "december" => 12,
             _ => {
                 return Err(
-                    ErrorKind::Expression(format!("'{}' is not a valid month name.", name)).into(),
+                    ErrorKind::Expression(format!("'{name}' is not a valid month name.")).into(),
                 )
             }
         };

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -12,9 +12,9 @@ mod tests {
     fn test_readme() {
         let expression = "0   30   9,12,15     1,15       May-Aug  Mon,Wed,Fri  2018/2";
         let schedule = Schedule::from_str(expression).unwrap();
-        println!("README: Upcoming fire times for '{}':", expression);
+        println!("README: Upcoming fire times for '{expression}':");
         for datetime in schedule.upcoming(TimeZone::UTC).take(10) {
-            println!("README: -> {}", datetime);
+            println!("README: -> {datetime}");
         }
     }
 
@@ -22,9 +22,9 @@ mod tests {
     fn test_anything_goes() {
         let expression = "* * * * * * *";
         let schedule = Schedule::from_str(expression).unwrap();
-        println!("All stars: Upcoming fire times for '{}':", expression);
+        println!("All stars: Upcoming fire times for '{expression}':");
         for datetime in schedule.upcoming(TimeZone::UTC).take(10) {
-            println!("All stars: -> {}", datetime);
+            println!("All stars: -> {datetime}");
         }
     }
 
@@ -45,10 +45,10 @@ mod tests {
         let expression = "1 2,17,51 1-3,6,9-11 4,29 2,3,7 Tues";
         let schedule = Schedule::from_str(expression).unwrap();
         let mut date = Zoned::now().with_time_zone(TimeZone::UTC);
-        println!("Fire times for {}:", expression);
+        println!("Fire times for {expression}:");
         for _ in 0..20 {
             date = schedule.after(&date).next().expect("No further dates!");
-            println!("-> {}", date);
+            println!("-> {date}");
         }
     }
 
@@ -56,9 +56,9 @@ mod tests {
     fn test_upcoming_iterator() {
         let expression = "0 2,17,51 1-3,6,9-11 4,29 2,3,7 Wed";
         let schedule = Schedule::from_str(expression).unwrap();
-        println!("Upcoming fire times for '{}':", expression);
+        println!("Upcoming fire times for '{expression}':");
         for datetime in schedule.upcoming(TimeZone::UTC).take(12) {
-            println!("-> {}", datetime);
+            println!("-> {datetime}");
         }
     }
 
@@ -88,7 +88,7 @@ mod tests {
             .upcoming(TimeZone::UTC)
             .next()
             .expect("There was no upcoming fire time.");
-        println!("Next fire time: {}", next);
+        println!("Next fire time: {next}");
     }
 
     #[test]
@@ -99,7 +99,7 @@ mod tests {
             .upcoming(TimeZone::UTC)
             .next_back()
             .expect("There was no previous upcoming fire time.");
-        println!("Previous fire time: {}", prev);
+        println!("Previous fire time: {prev}");
     }
 
     #[test]


### PR DESCRIPTION
Fix `clippy::uninlined_format_args` by inlining the format arguments (by running `cargo clippy --fix` and reviewing the changes).