### PR TITLE
feat: add Debug + Clone derives to OwnedScheduleIterator

### DIFF
--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -456,6 +456,7 @@ impl ScheduleFields {
     }
 }
 
+#[derive(Clone, Debug)]
 pub struct ScheduleIterator<'a> {
     schedule: &'a Schedule,
     previous_datetime: Option<Zoned>,
@@ -500,6 +501,7 @@ impl DoubleEndedIterator for ScheduleIterator<'_> {
 }
 
 /// A `ScheduleIterator` with a static lifetime.
+#[derive(Clone, Debug)]
 pub struct OwnedScheduleIterator {
     schedule: Schedule,
     previous_datetime: Option<Zoned>,

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -63,6 +63,17 @@ mod tests {
     }
 
     #[test]
+    fn test_upcoming_owned_iterator() {
+        let expression = "0 2,17,51 1-3,6,9-11 4,29 2,3,7 Wed";
+        let schedule = Schedule::from_str(expression).unwrap();
+        let upcoming_owned_iter = schedule.upcoming_owned(TimeZone::UTC);
+        println!("Upcoming fire times for '{expression}':");
+        for datetime in upcoming_owned_iter.clone().take(12) {
+            println!("-> {datetime}");
+        }
+    }
+
+    #[test]
     fn test_parse_without_year() {
         let expression = "1 2 3 4 5 6";
         assert!(Schedule::from_str(expression).is_ok());


### PR DESCRIPTION
### Justification

Ran into a case where I needed to clone an `OwnedScheduleIterator` and saw it wasn't implemented. All the fields are `Clone`, so didn't think anybody would have any issue with me tacking it on (+ `Debug` while I'm here) and pushing it upstream. (correct me if I'm missing something though!)

### Changes

- `OwnedScheduleIterator` now implements `Debug` and `Clone`
- Addressed clippy fixes in the tests (["useless use of `vec!`"](https://rust-lang.github.io/rust-clippy/rust-1.91.0/index.html#useless_vec))
- Added August to `test_parse_with_lists` expression (was failing since there doesn't seem to be a Tuesday in February, March, or July that's also the 4th or 29th day of the month in 2026)

### Effects

- `OwnedScheduleIterator` should be `.clone()`-able

---

- [x] Linked relevant ticket, or provided justification for change
- [x] Unit testing:
  - [x] Implemented/updated.
  - [x] Run locally without any failures.
  - [x] Run in PR pipeline without any failures.
- [x] Linter scan for branch has no new issues and tests introduce > 80% coverage.
- [x] Release
  - [x] Author of PR is available during deployment time to monitor release.