### PR TITLE
ci: enforce canonical `#[derive]` order

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,6 +23,12 @@ jobs:
       - name: rustfmt
         run: |
           cargo +nightly --locked fmt --all -- --check
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: keepsorted
+      - name: keepsorted
+        run: |
+          keepsorted -r -f rust_derive_canonical --diff .
 
   check-docs:
     runs-on: ubuntu-latest

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -53,7 +53,7 @@ impl FromStr for Schedule {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(PartialEq, Debug)]
 pub struct Field {
     pub specifiers: Vec<RootSpecifier>, // TODO: expose iterator?
 }

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -15,7 +15,7 @@ impl From<Schedule> for String {
     }
 }
 
-#[derive(Clone, Debug, Eq)]
+#[derive(Clone, Eq, Debug)]
 pub struct Schedule {
     source: String,
     fields: ScheduleFields,
@@ -423,7 +423,7 @@ impl PartialEq for Schedule {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Eq, PartialEq, Debug)]
 pub struct ScheduleFields {
     years: Years,
     days_of_week: DaysOfWeek,

--- a/src/specifier.rs
+++ b/src/specifier.rs
@@ -1,6 +1,6 @@
 use crate::ordinal::*;
 
-#[derive(Debug, PartialEq)]
+#[derive(PartialEq, Debug)]
 pub enum Specifier {
     All,
     Point(Ordinal),
@@ -17,7 +17,7 @@ pub enum Specifier {
 //
 // Without this separation we would end up with invalid combinations such as
 // 'Mon/2'
-#[derive(Debug, PartialEq)]
+#[derive(PartialEq, Debug)]
 pub enum RootSpecifier {
     Specifier(Specifier),
     Period(Specifier, u32),

--- a/src/time_unit/days_of_month.rs
+++ b/src/time_unit/days_of_month.rs
@@ -7,7 +7,7 @@ use crate::{
 
 static ALL: LazyLock<OrdinalSet> = LazyLock::new(DaysOfMonth::supported_ordinals);
 
-#[derive(Clone, Debug, Eq)]
+#[derive(Clone, Eq, Debug)]
 pub struct DaysOfMonth {
     ordinals: Option<OrdinalSet>,
 }

--- a/src/time_unit/days_of_week.rs
+++ b/src/time_unit/days_of_week.rs
@@ -8,7 +8,7 @@ use crate::{
 
 static ALL: LazyLock<OrdinalSet> = LazyLock::new(DaysOfWeek::supported_ordinals);
 
-#[derive(Clone, Debug, Eq)]
+#[derive(Clone, Eq, Debug)]
 pub struct DaysOfWeek {
     ordinals: Option<OrdinalSet>,
 }

--- a/src/time_unit/hours.rs
+++ b/src/time_unit/hours.rs
@@ -7,7 +7,7 @@ use crate::{
 
 static ALL: LazyLock<OrdinalSet> = LazyLock::new(Hours::supported_ordinals);
 
-#[derive(Clone, Debug, Eq)]
+#[derive(Clone, Eq, Debug)]
 pub struct Hours {
     ordinals: Option<OrdinalSet>,
 }

--- a/src/time_unit/minutes.rs
+++ b/src/time_unit/minutes.rs
@@ -7,7 +7,7 @@ use crate::{
 
 static ALL: LazyLock<OrdinalSet> = LazyLock::new(Minutes::supported_ordinals);
 
-#[derive(Clone, Debug, Eq)]
+#[derive(Clone, Eq, Debug)]
 pub struct Minutes {
     ordinals: Option<OrdinalSet>,
 }

--- a/src/time_unit/months.rs
+++ b/src/time_unit/months.rs
@@ -8,7 +8,7 @@ use crate::{
 
 static ALL: LazyLock<OrdinalSet> = LazyLock::new(Months::supported_ordinals);
 
-#[derive(Clone, Debug, Eq)]
+#[derive(Clone, Eq, Debug)]
 pub struct Months {
     ordinals: Option<OrdinalSet>,
 }

--- a/src/time_unit/seconds.rs
+++ b/src/time_unit/seconds.rs
@@ -7,7 +7,7 @@ use crate::{
 
 static ALL: LazyLock<OrdinalSet> = LazyLock::new(Seconds::supported_ordinals);
 
-#[derive(Clone, Debug, Eq)]
+#[derive(Clone, Eq, Debug)]
 pub struct Seconds {
     ordinals: Option<OrdinalSet>,
 }

--- a/src/time_unit/years.rs
+++ b/src/time_unit/years.rs
@@ -7,7 +7,7 @@ use crate::{
 
 static ALL: LazyLock<OrdinalSet> = LazyLock::new(Years::supported_ordinals);
 
-#[derive(Clone, Debug, Eq)]
+#[derive(Clone, Eq, Debug)]
 pub struct Years {
     ordinals: Option<OrdinalSet>,
 }


### PR DESCRIPTION
Implements #42.