### PR TITLE
perf: replace month/day-of-week match expressions by `phf` maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update links to point to the `jiff-cron` GitHub organization (https://github.com/jiff-cron/jiff-cron/commit/1eff14a82e19a305d684044aa11e92500e4a6b43) by @maxcountryman
 - Re-implement next\_after/prev\_from logic to support jiff 0.2/DST (https://github.com/jiff-cron/jiff-cron/pull/31) by @StephanvanSchaik
 - Migrate from `nom` to `winnow` (https://github.com/jiff-cron/jiff-cron/pull/38) by @epage, with improvements by @AlexTMjugador, ported by @LeoniePhiline
+- Refactor month and day-of-week name parsing to use perfect hash function (`phf`) maps instead of match expressions, improving lookup performance and code maintainability. (https://github.com/jiff-cron/jiff-cron/pull/38) by @sbquinlan, ported by @LeoniePhiline
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ edition = "2021"
 
 [dependencies]
 jiff = "0.2"
+phf = { version = "0.11", features = ["macros"] }
 serde = { version = "1", optional = true }
 winnow = { version = "1.0", default-features = false, features = ["ascii", "std"] }
 

--- a/src/time_unit/days_of_week.rs
+++ b/src/time_unit/days_of_week.rs
@@ -1,9 +1,30 @@
 use std::{borrow::Cow, sync::LazyLock};
 
+use phf::phf_map;
+
 use crate::{
     error::*,
     ordinal::{Ordinal, OrdinalSet},
     time_unit::TimeUnitField,
+};
+
+static DAY_OF_WEEK_MAP: phf::Map<&'static str, Ordinal> = phf_map! {
+    "sun" => 1,
+    "sunday" => 1,
+    "mon" => 2,
+    "monday" => 2,
+    "tue" => 3,
+    "tues" => 3,
+    "tuesday" => 3,
+    "wed" => 4,
+    "wednesday" => 4,
+    "thu" => 5,
+    "thurs" => 5,
+    "thursday" => 5,
+    "fri" => 6,
+    "friday" => 6,
+    "sat" => 7,
+    "saturday" => 7,
 };
 
 static ALL: LazyLock<OrdinalSet> = LazyLock::new(DaysOfWeek::supported_ordinals);
@@ -29,23 +50,12 @@ impl TimeUnitField for DaysOfWeek {
         7
     }
     fn ordinal_from_name(name: &str) -> Result<Ordinal, Error> {
-        //TODO: Use phf crate
-        let ordinal = match name.to_lowercase().as_ref() {
-            "sun" | "sunday" => 1,
-            "mon" | "monday" => 2,
-            "tue" | "tues" | "tuesday" => 3,
-            "wed" | "wednesday" => 4,
-            "thu" | "thurs" | "thursday" => 5,
-            "fri" | "friday" => 6,
-            "sat" | "saturday" => 7,
-            _ => {
-                return Err(ErrorKind::Expression(format!(
-                    "'{name}' is not a valid day of the week."
-                ))
-                .into())
-            }
-        };
-        Ok(ordinal)
+        DAY_OF_WEEK_MAP
+            .get(name.to_lowercase().as_ref())
+            .copied()
+            .ok_or_else(|| {
+                ErrorKind::Expression(format!("'{name}' is not a valid day of the week.")).into()
+            })
     }
     fn ordinals(&self) -> &OrdinalSet {
         match &self.ordinals {

--- a/src/time_unit/months.rs
+++ b/src/time_unit/months.rs
@@ -1,9 +1,37 @@
 use std::{borrow::Cow, sync::LazyLock};
 
+use phf::phf_map;
+
 use crate::{
     error::*,
     ordinal::{Ordinal, OrdinalSet},
     time_unit::TimeUnitField,
+};
+
+static MONTH_MAP: phf::Map<&'static str, Ordinal> = phf_map! {
+    "jan" => 1,
+    "january" => 1,
+    "feb" => 2,
+    "february" => 2,
+    "mar" => 3,
+    "march" => 3,
+    "apr" => 4,
+    "april" => 4,
+    "may" => 5,
+    "jun" => 6,
+    "june" => 6,
+    "jul" => 7,
+    "july" => 7,
+    "aug" => 8,
+    "august" => 8,
+    "sep" => 9,
+    "september" => 9,
+    "oct" => 10,
+    "october" => 10,
+    "nov" => 11,
+    "november" => 11,
+    "dec" => 12,
+    "december" => 12,
 };
 
 static ALL: LazyLock<OrdinalSet> = LazyLock::new(Months::supported_ordinals);
@@ -29,27 +57,12 @@ impl TimeUnitField for Months {
         12
     }
     fn ordinal_from_name(name: &str) -> Result<Ordinal, Error> {
-        //TODO: Use phf crate
-        let ordinal = match name.to_lowercase().as_ref() {
-            "jan" | "january" => 1,
-            "feb" | "february" => 2,
-            "mar" | "march" => 3,
-            "apr" | "april" => 4,
-            "may" => 5,
-            "jun" | "june" => 6,
-            "jul" | "july" => 7,
-            "aug" | "august" => 8,
-            "sep" | "september" => 9,
-            "oct" | "october" => 10,
-            "nov" | "november" => 11,
-            "dec" | "december" => 12,
-            _ => {
-                return Err(
-                    ErrorKind::Expression(format!("'{name}' is not a valid month name.")).into(),
-                )
-            }
-        };
-        Ok(ordinal)
+        MONTH_MAP
+            .get(name.to_lowercase().as_ref())
+            .copied()
+            .ok_or_else(|| {
+                ErrorKind::Expression(format!("'{name}' is not a valid month name.")).into()
+            })
     }
     fn ordinals(&self) -> &OrdinalSet {
         match &self.ordinals {


### PR DESCRIPTION
Ports https://github.com/zslayton/cron/pull/142
for parity with `cron`.

Implements #44.