### PR TITLE
fix: constrain day range at month reset to handle non-leap years at Feb 29

### DIFF
--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -1029,6 +1029,30 @@ mod test {
     }
 
     #[test]
+    fn test_no_panic_on_year_ordinals_exhausted_after() {
+        let schedule_tz: TimeZone = TimeZone::get("Europe/London").unwrap();
+        let dt = DateTime::new(2100, 12, 31, 0, 0, 0, 0)
+            .unwrap()
+            .to_zoned(schedule_tz)
+            .unwrap();
+
+        let schedule = Schedule::from_str("* * * * * Sat,Sun *").unwrap();
+        assert!(schedule.after(&dt).next().is_none());
+    }
+
+    #[test]
+    fn test_no_panic_on_year_ordinals_exhausted_before() {
+        let schedule_tz: TimeZone = TimeZone::get("Europe/London").unwrap();
+        let dt = DateTime::new(1970, 1, 1, 0, 0, 0, 0)
+            .unwrap()
+            .to_zoned(schedule_tz)
+            .unwrap();
+
+        let schedule = Schedule::from_str("* * * * * Sat,Sun *").unwrap();
+        assert!(schedule.after(&dt).next_back().is_none());
+    }
+
+    #[test]
     fn test_no_panic_on_leap_day_time_after() {
         let dt = "2024-02-29T10:00:00.000+08:00[Asia/Singapore]" // N.B. TZ inferred from original
             .parse()

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -27,35 +27,35 @@ impl Schedule {
     }
 
     // Get the set of ordinals for the given unit.
-    fn ordinals(&self, unit: Unit) -> Option<&OrdinalSet> {
-        Some(match unit {
+    fn ordinals(&self, unit: Unit) -> &OrdinalSet {
+        match unit {
             Unit::Second => self.fields.seconds.ordinals(),
             Unit::Minute => self.fields.minutes.ordinals(),
             Unit::Hour => self.fields.hours.ordinals(),
             Unit::Day => self.fields.days_of_month.ordinals(),
             Unit::Month => self.fields.months.ordinals(),
             Unit::Year => self.fields.years.ordinals(),
-            _ => return None,
-        })
+            _ => unreachable!(),
+        }
     }
 
     // Get the current value for the corresponding unit in the given timestamp with
     // associated timezone.
-    fn current(zoned: &Zoned, unit: Unit) -> Option<u32> {
-        Some(match unit {
+    fn current(zoned: &Zoned, unit: Unit) -> u32 {
+        match unit {
             Unit::Second => zoned.second() as u32,
             Unit::Minute => zoned.minute() as u32,
             Unit::Hour => zoned.hour() as u32,
             Unit::Day => zoned.day() as u32,
             Unit::Month => zoned.month() as u32,
             Unit::Year => zoned.year() as u32,
-            _ => return None,
-        })
+            _ => unreachable!(),
+        }
     }
 
     fn adjust_next(&self, mut zoned: Zoned, unit: Unit) -> Option<Zoned> {
-        let ordinals = self.ordinals(unit)?;
-        let current = Self::current(&zoned, unit)?;
+        let ordinals = self.ordinals(unit);
+        let current = Self::current(&zoned, unit);
 
         // Determine the next ordinal to use for the given unit and timestamp.
         let interval = ordinals
@@ -75,7 +75,7 @@ impl Schedule {
             Unit::Day => interval.days(),
             Unit::Month => interval.months(),
             Unit::Year => interval.years(),
-            _ => return None,
+            _ => unreachable!(),
         };
 
         zoned = zoned.checked_add(interval).ok()?;
@@ -84,8 +84,8 @@ impl Schedule {
     }
 
     fn adjust_prev(&self, mut zoned: Zoned, unit: Unit) -> Option<Zoned> {
-        let ordinals = self.ordinals(unit)?;
-        let current = Self::current(&zoned, unit)?;
+        let ordinals = self.ordinals(unit);
+        let current = Self::current(&zoned, unit);
 
         // Determine the previous ordinal to use for the given unit and timestamp.
         let interval = ordinals
@@ -101,7 +101,7 @@ impl Schedule {
             Unit::Day => interval.days(),
             Unit::Month => interval.months(),
             Unit::Year => interval.years(),
-            _ => return None,
+            _ => unreachable!(),
         };
 
         zoned = zoned.checked_sub(interval).ok()?;
@@ -110,19 +110,22 @@ impl Schedule {
     }
 
     fn reset_next(&self, zoned: Zoned, unit: Unit) -> Option<Zoned> {
-        let ordinals = self.ordinals(unit)?;
+        let ordinals = self.ordinals(unit);
 
         // `Month` reset must jointly set `Day` to respect the days-in-month constraint.
         //
         // Iterate months in ascending order.
         // For each, find the first valid day ordinal.
         if let Unit::Month = unit {
-            let day_ordinals = self.ordinals(Unit::Day)?;
+            let day_ordinals = self.ordinals(Unit::Day);
 
             for &month_ordinal in ordinals.iter() {
-                let Ok(month) = zoned.with().month(month_ordinal as i8).day(1).build() else {
-                    continue;
-                };
+                let month = zoned
+                    .with()
+                    .month(month_ordinal as i8)
+                    .day(1)
+                    .build()
+                    .expect("month ordinals are constrained");
 
                 let days_in_month = month.days_in_month() as u32;
                 if let Some(&day_ordinal) = day_ordinals
@@ -149,25 +152,27 @@ impl Schedule {
             Unit::Minute => zoned.with().minute(first as i8).build().ok()?,
             Unit::Hour => zoned.with().hour(first as i8).build().ok()?,
             Unit::Day => zoned.with().day(first as i8).build().ok()?,
-            Unit::Year => zoned.with().year(first as i16).build().ok()?,
-            _ => return None,
+            _ => unreachable!(),
         })
     }
 
     fn reset_prev(&self, zoned: Zoned, unit: Unit) -> Option<Zoned> {
-        let ordinals = self.ordinals(unit)?;
+        let ordinals = self.ordinals(unit);
 
         // `Month` reset must jointly set `Day` to respect the days-in-month constraint.
         //
         // Iterate months in descending order.
         // For each, find the last valid day ordinal.
         if let Unit::Month = unit {
-            let day_ordinals = self.ordinals(Unit::Day)?;
+            let day_ordinals = self.ordinals(Unit::Day);
 
             for &month_ordinal in ordinals.iter().rev() {
-                let Ok(month) = zoned.with().month(month_ordinal as i8).day(1).build() else {
-                    continue;
-                };
+                let month = zoned
+                    .with()
+                    .month(month_ordinal as i8)
+                    .day(1)
+                    .build()
+                    .expect("month ordinals are constrained");
 
                 let days_in_month = month.days_in_month() as u32;
                 if let Some(&day_ordinal) = day_ordinals
@@ -200,8 +205,7 @@ impl Schedule {
             Unit::Minute => zoned.with().minute(last as i8).build().ok()?,
             Unit::Hour => zoned.with().hour(last as i8).build().ok()?,
             Unit::Day => zoned.with().day(last as i8).build().ok()?,
-            Unit::Year => zoned.with().year(last as i16).build().ok()?,
-            _ => return None,
+            _ => unreachable!(),
         })
     }
 
@@ -231,8 +235,8 @@ impl Schedule {
 
             for unit in &units {
                 let unit = *unit;
-                let ordinals = self.ordinals(unit)?;
-                let current = Self::current(&candidate, unit)?;
+                let ordinals = self.ordinals(unit);
+                let current = Self::current(&candidate, unit);
 
                 valid &= ordinals.contains(&current);
             }
@@ -261,8 +265,8 @@ impl Schedule {
                 // Check if all larger units have valid ordinals.
                 // Otherwise we have to try the next smallest possible unit.
                 for unit in &units[i..] {
-                    let ordinals = self.ordinals(*unit)?;
-                    let current = Self::current(&adjusted_candidate, *unit)?;
+                    let ordinals = self.ordinals(*unit);
+                    let current = Self::current(&adjusted_candidate, *unit);
 
                     if !ordinals.contains(&current) {
                         continue 'units;
@@ -337,8 +341,8 @@ impl Schedule {
 
             for unit in &units {
                 let unit = *unit;
-                let ordinals = self.ordinals(unit)?;
-                let current = Self::current(&candidate, unit)?;
+                let ordinals = self.ordinals(unit);
+                let current = Self::current(&candidate, unit);
 
                 valid &= ordinals.contains(&current);
             }
@@ -367,8 +371,8 @@ impl Schedule {
                 // Check if all larger units have valid ordinals.
                 // Otherwise we have to try the next smallest possible unit.
                 for unit in &units[i..] {
-                    let ordinals = self.ordinals(*unit)?;
-                    let current = Self::current(&adjusted_candidate, *unit)?;
+                    let ordinals = self.ordinals(*unit);
+                    let current = Self::current(&adjusted_candidate, *unit);
 
                     if !ordinals.contains(&current) {
                         continue 'units;

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -87,7 +87,7 @@ impl Schedule {
         let ordinals = self.ordinals(unit)?;
         let current = Self::current(&zoned, unit)?;
 
-        // Determine the next ordinal to use for the given unit and timestamp.
+        // Determine the previous ordinal to use for the given unit and timestamp.
         let interval = ordinals
             .range(..current)
             .next_back()
@@ -110,40 +110,96 @@ impl Schedule {
     }
 
     fn reset_next(&self, zoned: Zoned, unit: Unit) -> Option<Zoned> {
-        // Pick the first available ordinal for the given unit.
         let ordinals = self.ordinals(unit)?;
+
+        // `Month` reset must jointly set `Day` to respect the days-in-month constraint.
+        //
+        // Iterate months in ascending order.
+        // For each, find the first valid day ordinal.
+        if let Unit::Month = unit {
+            let day_ordinals = self.ordinals(Unit::Day)?;
+
+            for &month_ordinal in ordinals.iter() {
+                let Ok(month) = zoned.with().month(month_ordinal as i8).day(1).build() else {
+                    continue;
+                };
+
+                let days_in_month = month.days_in_month() as u32;
+                if let Some(&day_ordinal) = day_ordinals
+                    .iter()
+                    .find(|&&day_ordinal| day_ordinal <= days_in_month)
+                {
+                    return zoned
+                        .with()
+                        .month(month_ordinal as i8)
+                        .day(day_ordinal as i8)
+                        .build()
+                        .ok();
+                }
+            }
+
+            return None;
+        }
+
+        // Pick the first available ordinal for the given unit.
         let first = *ordinals.first()?;
 
-        // Simply replace the value of the corresponding unit.
         Some(match unit {
             Unit::Second => zoned.with().second(first as i8).build().ok()?,
             Unit::Minute => zoned.with().minute(first as i8).build().ok()?,
             Unit::Hour => zoned.with().hour(first as i8).build().ok()?,
             Unit::Day => zoned.with().day(first as i8).build().ok()?,
-            Unit::Month => zoned.with().month(first as i8).build().ok()?,
             Unit::Year => zoned.with().year(first as i16).build().ok()?,
             _ => return None,
         })
     }
 
     fn reset_prev(&self, zoned: Zoned, unit: Unit) -> Option<Zoned> {
+        let ordinals = self.ordinals(unit)?;
+
+        // `Month` reset must jointly set `Day` to respect the days-in-month constraint.
+        //
+        // Iterate months in descending order.
+        // For each, find the last valid day ordinal.
+        if let Unit::Month = unit {
+            let day_ordinals = self.ordinals(Unit::Day)?;
+
+            for &month_ordinal in ordinals.iter().rev() {
+                let Ok(month) = zoned.with().month(month_ordinal as i8).day(1).build() else {
+                    continue;
+                };
+
+                let days_in_month = month.days_in_month() as u32;
+                if let Some(&day_ordinal) = day_ordinals
+                    .iter()
+                    .rev()
+                    .find(|&&day_ordinal| day_ordinal <= days_in_month)
+                {
+                    return zoned
+                        .with()
+                        .month(month_ordinal as i8)
+                        .day(day_ordinal as i8)
+                        .build()
+                        .ok();
+                }
+            }
+
+            return None;
+        }
+
         // Pick the last available ordinal for the given unit. Ensure that if we are
         // working with days, that we do not pick ordinals greater than the
         // number of days in the current month.
-        let ordinals = self.ordinals(unit)?;
-
         let last = *ordinals.iter().rev().find(|next| match unit {
             Unit::Day => **next <= zoned.days_in_month() as u32,
             _ => true,
         })?;
 
-        // Simply replace the value of the corresponding unit.
         Some(match unit {
             Unit::Second => zoned.with().second(last as i8).build().ok()?,
             Unit::Minute => zoned.with().minute(last as i8).build().ok()?,
             Unit::Hour => zoned.with().hour(last as i8).build().ok()?,
             Unit::Day => zoned.with().day(last as i8).build().ok()?,
-            Unit::Month => zoned.with().month(last as i8).build().ok()?,
             Unit::Year => zoned.with().year(last as i16).build().ok()?,
             _ => return None,
         })
@@ -158,10 +214,10 @@ impl Schedule {
             Unit::Month,
             Unit::Year,
         ];
-        let mut candidate = after.clone();
 
         // First try rounding up the candidate to the nearest second.
-        let rounded = candidate
+        let mut candidate = after
+            .clone()
             .round(
                 ZonedRound::new()
                     .smallest(Unit::Second)
@@ -170,54 +226,75 @@ impl Schedule {
             .ok()?;
 
         // If all fields have valid ordinals, return the rounded timestamp.
-        if rounded != candidate {
+        if candidate != *after {
             let mut valid = true;
 
             for unit in &units {
                 let unit = *unit;
                 let ordinals = self.ordinals(unit)?;
-                let current = Self::current(&rounded, unit)?;
+                let current = Self::current(&candidate, unit)?;
 
                 valid &= ordinals.contains(&current);
             }
 
             if valid {
-                return Some(rounded);
+                return Some(candidate);
             }
         }
 
-        candidate = rounded;
+        'candidates: loop {
+            let mut units_iter = units.iter().enumerate();
 
-        loop {
-            'outer: for (i, unit) in units.iter().enumerate() {
-                // Determine the smallest possible unit for which we can simply pick the next
-                // ordinal without wrapping around.
-                let Some(new_candidate) = self.adjust_next(candidate.clone(), *unit) else {
-                    continue;
+            candidate = 'units: loop {
+                let Some((i, unit)) = units_iter.next() else {
+                    // No valid candidate could be found,
+                    // exhausting all possible valid ordinals (e.g., year > 2100).
+                    return None;
                 };
 
-                // Check if all larger units have valid ordinals. Otherwise we have to try the
-                // next smallest possible unit.
+                // Determine the smallest possible unit for which we can
+                // simply pick the next larger ordinal without wrapping around.
+                let Some(adjusted_candidate) = self.adjust_next(candidate.clone(), *unit) else {
+                    continue 'units;
+                };
+
+                // Check if all larger units have valid ordinals.
+                // Otherwise we have to try the next smallest possible unit.
                 for unit in &units[i..] {
                     let ordinals = self.ordinals(*unit)?;
-                    let current = Self::current(&new_candidate, *unit)?;
+                    let current = Self::current(&adjusted_candidate, *unit)?;
 
                     if !ordinals.contains(&current) {
-                        continue 'outer;
+                        continue 'units;
                     }
                 }
 
                 // At this point we found a suitable candidate for which we have to reset the
                 // values corresponding to the units smaller than the unit we found. We simply
                 // pick the smallest possible ordinal for each.
-                candidate = new_candidate;
+
+                let mut reset_candidate = adjusted_candidate.clone();
 
                 for unit in units[..i].iter().rev() {
-                    candidate = self.reset_next(candidate, *unit)?;
+                    match self.reset_next(reset_candidate.clone(), *unit) {
+                        Some(reset_result) => reset_candidate = reset_result,
+                        None => {
+                            // Unit reset had no valid ordinal. Discard reset candidate.
+                            //
+                            // Advance past the failed position so the next iteration
+                            // tries a later starting point (e.g., the next year).
+                            candidate = adjusted_candidate;
+
+                            // Reset failed; retry from the advanced candidate.
+                            continue 'candidates;
+                        }
+                    }
                 }
 
-                break;
-            }
+                // Reset succeeded.
+                // Go forward with reset candidate for day of week check.
+                break 'units reset_candidate;
+            };
 
             // Keep going until the weekday is valid for this schedule.
             if !self
@@ -226,7 +303,7 @@ impl Schedule {
                 .ordinals()
                 .contains(&(candidate.weekday().to_sunday_one_offset() as u32))
             {
-                continue;
+                continue 'candidates;
             }
 
             // This is the next possible candidate that adheres to the schedule.
@@ -243,10 +320,10 @@ impl Schedule {
             Unit::Month,
             Unit::Year,
         ];
-        let mut candidate = before.clone();
 
         // First try rounding up the candidate to the nearest second.
-        let rounded = candidate
+        let mut candidate = before
+            .clone()
             .round(
                 ZonedRound::new()
                     .smallest(Unit::Second)
@@ -255,54 +332,75 @@ impl Schedule {
             .ok()?;
 
         // If all fields have valid ordinals, return the rounded timestamp.
-        if rounded != candidate {
+        if candidate != *before {
             let mut valid = true;
 
             for unit in &units {
                 let unit = *unit;
                 let ordinals = self.ordinals(unit)?;
-                let current = Self::current(&rounded, unit)?;
+                let current = Self::current(&candidate, unit)?;
 
                 valid &= ordinals.contains(&current);
             }
 
             if valid {
-                return Some(rounded);
+                return Some(candidate);
             }
         }
 
-        candidate = rounded;
+        'candidates: loop {
+            let mut units_iter = units.iter().enumerate();
 
-        loop {
-            'outer: for (i, unit) in units.iter().enumerate() {
-                // Determine the smallest possible unit for which we can simply pick the next
-                // ordinal without wrapping around.
-                let Some(new_candidate) = self.adjust_prev(candidate.clone(), *unit) else {
-                    continue;
+            candidate = 'units: loop {
+                let Some((i, unit)) = units_iter.next() else {
+                    // No valid candidate could be found,
+                    // exhausting all possible valid ordinals (e.g., year < 1970).
+                    return None;
                 };
 
-                // Check if all larger units have valid ordinals. Otherwise we have to try the
-                // next smallest possible unit.
+                // Determine the smallest possible unit for which we can
+                // simply pick the next smaller ordinal without wrapping around.
+                let Some(adjusted_candidate) = self.adjust_prev(candidate.clone(), *unit) else {
+                    continue 'units;
+                };
+
+                // Check if all larger units have valid ordinals.
+                // Otherwise we have to try the next smallest possible unit.
                 for unit in &units[i..] {
                     let ordinals = self.ordinals(*unit)?;
-                    let current = Self::current(&new_candidate, *unit)?;
+                    let current = Self::current(&adjusted_candidate, *unit)?;
 
                     if !ordinals.contains(&current) {
-                        continue 'outer;
+                        continue 'units;
                     }
                 }
 
                 // At this point we found a suitable candidate for which we have to reset the
                 // values corresponding to the units smaller than the unit we found. We simply
                 // pick the greatest possible ordinal for each.
-                candidate = new_candidate;
+
+                let mut reset_candidate = adjusted_candidate.clone();
 
                 for unit in units[..i].iter().rev() {
-                    candidate = self.reset_prev(candidate, *unit)?;
+                    match self.reset_prev(reset_candidate.clone(), *unit) {
+                        Some(reset_result) => reset_candidate = reset_result,
+                        None => {
+                            // Unit reset had no valid ordinal. Discard reset candidate.
+                            //
+                            // Advance past the failed position so the next iteration
+                            // tries an earlier starting point (e.g., the previous year).
+                            candidate = adjusted_candidate;
+
+                            // Reset failed; retry from the advanced candidate.
+                            continue 'candidates;
+                        }
+                    }
                 }
 
-                break;
-            }
+                // Reset succeeded.
+                // Go forward with reset candidate for day of week check.
+                break 'units reset_candidate;
+            };
 
             // Keep going until the weekday is valid for this schedule.
             if !self

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -52,6 +52,90 @@ mod tests {
         }
     }
 
+    /// Leap year multi-year-skip regression test for <https://github.com/jiff-cron/jiff-cron/issues/41>.
+    ///
+    /// The non-deterministic `test_parse_with_lists`, using `Zoned::now`,
+    /// only succeeds in leap years before February 29th,
+    /// or in years before a leap year, after February 28th.
+    ///
+    /// This deterministic test asserts non-leap years being skipped
+    /// on a "Every February 29th" schedule.
+    ///
+    /// 2024 was a leap year. 2025, 2025 and 2027 are non leap years.
+    /// The next date for "Every February 29th" on 2026-01-01
+    /// must skip the non-existent 2026-02-29 and 2027-02-29,
+    /// and yield 2028-02-29.
+    #[test]
+    fn test_next_feb29_skips_non_leap_years() {
+        let schedule = Schedule::from_str("0 0 0 29 2 *").unwrap();
+        let start = jiff::civil::date(2026, 1, 1)
+            .at(0, 0, 0, 0)
+            .to_zoned(TimeZone::UTC)
+            .unwrap();
+        let next = schedule.after(&start).next().unwrap();
+        assert_eq!(
+            next,
+            jiff::civil::date(2028, 2, 29)
+                .at(0, 0, 0, 0)
+                .to_zoned(TimeZone::UTC)
+                .unwrap()
+        );
+    }
+
+    /// Leap year month-skip regression test for <https://github.com/jiff-cron/jiff-cron/issues/41>.
+    ///
+    /// The non-deterministic `test_parse_with_lists`, using `Zoned::now`,
+    /// only succeeds in leap years before February 29th,
+    /// or in years before a leap year, after February 28th.
+    ///
+    /// This deterministic test asserts the February of non-leap years being
+    /// skipped on a "Every February 29th and March 29th" schedule.
+    ///
+    /// 2024 was a leap year. 2025, 2025 and 2027 are non leap years.
+    /// The next date for "Every February 29th and March 29th" on 2026-01-01
+    /// must skip the non-existent 2026-02-09 and yield 2026-03-29.
+    #[test]
+    fn test_next_feb_or_mar29_skips_feb_in_non_leap_year() {
+        let schedule = Schedule::from_str("0 0 0 29 2,3 *").unwrap();
+        let start = jiff::civil::date(2026, 1, 1)
+            .at(0, 0, 0, 0)
+            .to_zoned(TimeZone::UTC)
+            .unwrap();
+        let next = schedule.after(&start).next().unwrap();
+        assert_eq!(
+            next,
+            jiff::civil::date(2026, 3, 29)
+                .at(0, 0, 0, 0)
+                .to_zoned(TimeZone::UTC)
+                .unwrap()
+        );
+    }
+
+    /// Leap year reverse multi-year-skip regression test for <https://github.com/jiff-cron/jiff-cron/issues/41>.
+    ///
+    /// This deterministic test asserts non-leap years being skipped
+    /// when iterating backwards on a "Every February 29th" schedule.
+    ///
+    /// 2024 was a leap year. 2025, 2025 and 2027 are non leap years.
+    /// The next reverse iteration date for "Every February 29th" on 2026-01-01
+    /// must skip the non-existent 2025-02-29 and yield 2028-02-29.
+    #[test]
+    fn test_prev_feb29_skips_non_leap_years() {
+        let schedule = Schedule::from_str("0 0 0 29 2 *").unwrap();
+        let start = jiff::civil::date(2026, 1, 1)
+            .at(0, 0, 0, 0)
+            .to_zoned(TimeZone::UTC)
+            .unwrap();
+        let prev = schedule.after(&start).next_back().unwrap();
+        assert_eq!(
+            prev,
+            jiff::civil::date(2024, 2, 29)
+                .at(0, 0, 0, 0)
+                .to_zoned(TimeZone::UTC)
+                .unwrap()
+        );
+    }
+
     #[test]
     fn test_upcoming_iterator() {
         let expression = "0 2,17,51 1-3,6,9-11 4,29 2,3,7 Wed";


### PR DESCRIPTION
# 7897e269ee08dbb8908810c2b6c8e516c35a1ad2 – test: add non-deterministic leap year skip tests

`tests::test_parse_with_lists`, as well as the [three new deterministic leap year skip tests](https://github.com/jiff-cron/jiff-cron/pull/47/changes/7897e269ee08dbb8908810c2b6c8e516c35a1ad2#diff-6d1e3ec7ab6aaf7a94f9c1e9a423db6de6e4a1bec380dae17cc6e635f1db8854R55-R137) fail as intended, proving the bug described in #41.

# 38f96a7b193ed9bb0889500099a511b1fdc08915 – fix: constrain day range at month reset to handle non-leap years at Feb 29

A cross-field constraint exists, which had been disregarded by the algorithm in #31:

The day of the month (unit `Day`) must be ≤ the number of days in the probed month (unit `Month`). 

When the `Year` unit was advanced, it reset `Month` and `Day` independently. This lead to setting `Month` to February and `Day` to 29 even in non-leap years, such as 2027.

This was triggered when iterating for [schedule `"1 2,17,51 1-3,6,9-11 4,29 2,3,7 Tues"`](https://github.com/jiff-cron/jiff-cron/blob/013557f6fda3689b9ca8f6980ecfe2c711bee0d5/tests/lib.rs#L45), or, simplified, `"0 0 0 29 2 *"` ("repeat on every February 29th").

The disjoint reset of the `Day` and `Month` units caused `ZonedWith::build` to fail, propagating `None`, which terminated the iterator.

Instead of terminating the iterator, the next year must be tried, which may be a leap year.

# Related

- Fixes #41.
- Related to #31.