### PR TITLE
feat!: make API more idiomatic: caller allocates, `into_` iterator methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] <!-- release-date -->
 
+### BREAKING CHANGES
+
+- Make schedule iterator API more idiomatic (https://github.com/jiff-cron/jiff-cron/pull/51) by @LeoniePhiline. **Migration:**
+  - Replace `Schedule::upcoming_owned` by `Schedule::into_upcoming`.
+  - Replace `Schedule::after_owned` by `Schedule::into_after`.
+  - `Schedule::into_upcoming` now takes ownership of `Schedule`. Clone if required.
+  - `Schedule::after` now takes ownership of argument `after: Zoned`, rather than cloning internally. Clone if required.
+  - `Schedule::into_after` now takes ownership of `Schedule`. Clone if required.
+  - `OwnedScheduleIterator::new` is no longer public. Use `Schedule::into_after` instead.
+
 ### Changed
 
 - Eliminate various `clone`s in schedule iterator hot loops to improve performance (https://github.com/jiff-cron/jiff-cron/pull/49) by @LeoniePhiline.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ fn main() {
         .in_tz("America/Chicago")
         .unwrap();
     println!("Upcoming fire times:");
-    for datetime in schedule.after(&after_datetime).take(5) {
+    for datetime in schedule.after(after_datetime).take(5) {
         println!("→ {}", datetime);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@
 //!         .in_tz("America/Chicago")
 //!         .unwrap();
 //!     println!("Upcoming fire times:");
-//!     for datetime in schedule.after(&after_datetime).take(5) {
+//!     for datetime in schedule.after(after_datetime).take(5) {
 //!         println!("→ {}", datetime);
 //!     }
 //! }

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -419,24 +419,24 @@ impl Schedule {
     /// the schedule starting with the current time if applicable.
     pub fn upcoming(&self, timezone: TimeZone) -> ScheduleIterator<'_> {
         let after = Zoned::now().with_time_zone(timezone);
-        self.after(&after)
+        self.after(after)
     }
 
     /// The same, but with an iterator with a static ownership
-    pub fn upcoming_owned(&self, timezone: TimeZone) -> OwnedScheduleIterator {
+    pub fn into_upcoming(self, timezone: TimeZone) -> OwnedScheduleIterator {
         let after = Zoned::now().with_time_zone(timezone);
-        self.after_owned(after)
+        self.into_after(after)
     }
 
     /// Like the `upcoming` method, but allows you to specify a start time other
     /// than the present.
-    pub fn after(&self, after: &Zoned) -> ScheduleIterator<'_> {
+    pub fn after(&self, after: Zoned) -> ScheduleIterator<'_> {
         ScheduleIterator::new(self, after)
     }
 
     /// The same, but with a static ownership.
-    pub fn after_owned(&self, after: Zoned) -> OwnedScheduleIterator {
-        OwnedScheduleIterator::new(self.clone(), after)
+    pub fn into_after(self, after: Zoned) -> OwnedScheduleIterator {
+        OwnedScheduleIterator::new(self, after)
     }
 
     pub fn includes(&self, date_time: Zoned) -> bool {
@@ -560,10 +560,10 @@ pub struct ScheduleIterator<'a> {
 //TODO: Cutoff datetime?
 
 impl<'a> ScheduleIterator<'a> {
-    fn new(schedule: &'a Schedule, starting_datetime: &Zoned) -> Self {
+    fn new(schedule: &'a Schedule, starting_datetime: Zoned) -> Self {
         ScheduleIterator {
             schedule,
-            previous_datetime: Some(starting_datetime.clone()),
+            previous_datetime: Some(starting_datetime),
         }
     }
 }
@@ -604,7 +604,7 @@ pub struct OwnedScheduleIterator {
 }
 
 impl OwnedScheduleIterator {
-    pub fn new(schedule: Schedule, starting_datetime: Zoned) -> Self {
+    fn new(schedule: Schedule, starting_datetime: Zoned) -> Self {
         Self {
             schedule,
             previous_datetime: Some(starting_datetime),
@@ -766,7 +766,7 @@ mod test {
                 .unwrap(),
         ]
         .into_iter()
-        .eq(schedule.after(&starting_date).take(3)));
+        .eq(schedule.after(starting_date).take(3)));
     }
 
     #[cfg(feature = "serde")]
@@ -816,7 +816,7 @@ mod test {
                 .unwrap(),
         ]
         .into_iter()
-        .eq(schedule.after(&starting_date).take(7)));
+        .eq(schedule.after(starting_date).take(7)));
     }
 
     #[test]
@@ -906,7 +906,7 @@ mod test {
     fn test_upcoming_utc_owned() {
         let expression = "0 0,30 0,6,12,18 1,15 Jan-March Thurs";
         let schedule = Schedule::from_str(expression).unwrap();
-        let mut upcoming = schedule.upcoming_owned(TimeZone::UTC);
+        let mut upcoming = schedule.into_upcoming(TimeZone::UTC);
         let next1 = upcoming.next();
         assert!(next1.is_some());
         let next2 = upcoming.next();
@@ -938,7 +938,7 @@ mod test {
     fn test_upcoming_rev_utc_owned() {
         let expression = "0 0,30 0,6,12,18 1,15 Jan-March Thurs";
         let schedule = Schedule::from_str(expression).unwrap();
-        let mut upcoming = schedule.upcoming_owned(TimeZone::UTC).rev();
+        let mut upcoming = schedule.into_upcoming(TimeZone::UTC).rev();
         let prev1 = upcoming.next();
         assert!(prev1.is_some());
         let prev2 = upcoming.next();
@@ -1007,7 +1007,7 @@ mod test {
             .unwrap(); // puts it in the middle of the DST transition
 
         let schedule = Schedule::from_str("* * * * * Sat,Sun *").unwrap();
-        let next = schedule.after(&dt).next().unwrap();
+        let next = schedule.after(dt.clone()).next().unwrap();
         assert!(next > dt); // test is ensuring line above does not panic
     }
 
@@ -1022,7 +1022,7 @@ mod test {
             .unwrap(); // puts it in the middle of the DST transition
 
         let schedule = Schedule::from_str("* * * * * Sat,Sun *").unwrap();
-        let prev = schedule.after(&dt).next_back().unwrap();
+        let prev = schedule.after(dt.clone()).next_back().unwrap();
         assert!(prev < dt); // test is ensuring line above does not panic
     }
 
@@ -1035,7 +1035,7 @@ mod test {
             .unwrap();
 
         let schedule = Schedule::from_str("* * * * * Sat,Sun *").unwrap();
-        assert!(schedule.after(&dt).next().is_none());
+        assert!(schedule.after(dt).next().is_none());
     }
 
     #[test]
@@ -1047,16 +1047,15 @@ mod test {
             .unwrap();
 
         let schedule = Schedule::from_str("* * * * * Sat,Sun *").unwrap();
-        assert!(schedule.after(&dt).next_back().is_none());
+        assert!(schedule.after(dt).next_back().is_none());
     }
 
     #[test]
     fn test_no_panic_on_leap_day_time_after() {
-        let dt = "2024-02-29T10:00:00.000+08:00[Asia/Singapore]" // N.B. TZ inferred from original
-            .parse()
-            .unwrap();
+        let dt = Zoned::from_str("2024-02-29T10:00:00.000+08:00[Asia/Singapore]").unwrap(); // N.B. TZ inferred from original
+
         let schedule = Schedule::from_str("0 0 0 * * * 2100").unwrap();
-        let next = schedule.after(&dt).next().unwrap();
+        let next = schedule.after(dt.clone()).next().unwrap();
         assert!(next > dt); // test is ensuring line above does not panic
     }
 
@@ -1100,7 +1099,7 @@ mod test {
             .unwrap();
         let schedule = Schedule::from_str("0 0 * * * * *").unwrap();
         let times = schedule
-            .after(&dt)
+            .after(dt)
             .map(|x| x.to_string())
             .take(5)
             .collect::<Vec<_>>();
@@ -1124,7 +1123,7 @@ mod test {
             .unwrap();
         let schedule = Schedule::from_str("0 0 * * * * *").unwrap();
         let times = schedule
-            .after(&dt)
+            .after(dt)
             .map(|x| x.to_string())
             .rev()
             .take(5)

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -47,7 +47,7 @@ mod tests {
         let mut date = Zoned::now().with_time_zone(TimeZone::UTC);
         println!("Fire times for {expression}:");
         for _ in 0..20 {
-            date = schedule.after(&date).next().expect("No further dates!");
+            date = schedule.after(date).next().expect("No further dates!");
             println!("→ {date}");
         }
     }
@@ -72,7 +72,7 @@ mod tests {
             .at(0, 0, 0, 0)
             .to_zoned(TimeZone::UTC)
             .unwrap();
-        let next = schedule.after(&start).next().unwrap();
+        let next = schedule.after(start).next().unwrap();
         assert_eq!(
             next,
             jiff::civil::date(2028, 2, 29)
@@ -101,7 +101,7 @@ mod tests {
             .at(0, 0, 0, 0)
             .to_zoned(TimeZone::UTC)
             .unwrap();
-        let next = schedule.after(&start).next().unwrap();
+        let next = schedule.after(start).next().unwrap();
         assert_eq!(
             next,
             jiff::civil::date(2026, 3, 29)
@@ -126,7 +126,7 @@ mod tests {
             .at(0, 0, 0, 0)
             .to_zoned(TimeZone::UTC)
             .unwrap();
-        let prev = schedule.after(&start).next_back().unwrap();
+        let prev = schedule.after(start).next_back().unwrap();
         assert_eq!(
             prev,
             jiff::civil::date(2024, 2, 29)
@@ -150,7 +150,7 @@ mod tests {
     fn test_upcoming_owned_iterator() {
         let expression = "0 2,17,51 1-3,6,9-11 4,29 2,3,7 Wed";
         let schedule = Schedule::from_str(expression).unwrap();
-        let upcoming_owned_iter = schedule.upcoming_owned(TimeZone::UTC);
+        let upcoming_owned_iter = schedule.into_upcoming(TimeZone::UTC);
         println!("Upcoming fire times for '{expression}':");
         for datetime in upcoming_owned_iter.take(12) {
             println!("→ {datetime}");
@@ -205,7 +205,7 @@ mod tests {
             .at(14, 29, 36, 0)
             .to_zoned(TimeZone::UTC)
             .unwrap();
-        let mut events = schedule.after(&starting_date);
+        let mut events = schedule.after(starting_date);
         assert_eq!(
             date(2018, 1, 1)
                 .at(0, 0, 0, 0)
@@ -237,7 +237,7 @@ mod tests {
             .at(14, 29, 36, 0)
             .to_zoned(TimeZone::UTC)
             .unwrap();
-        let mut events = schedule.after(&starting_date);
+        let mut events = schedule.after(starting_date);
         assert_eq!(
             date(2017, 11, 1)
                 .at(0, 0, 0, 0)
@@ -269,7 +269,7 @@ mod tests {
             .at(14, 29, 36, 0)
             .to_zoned(TimeZone::UTC)
             .unwrap();
-        let mut events = schedule.after(&starting_date);
+        let mut events = schedule.after(starting_date);
         assert_eq!(
             date(2016, 12, 25)
                 .at(0, 0, 0, 0)
@@ -301,7 +301,7 @@ mod tests {
             .at(14, 29, 36, 0)
             .to_zoned(TimeZone::UTC)
             .unwrap();
-        let mut events = schedule.after(&starting_date);
+        let mut events = schedule.after(starting_date);
         assert_eq!(
             date(2016, 12, 24)
                 .at(0, 0, 0, 0)
@@ -333,7 +333,7 @@ mod tests {
             .at(22, 29, 36, 0)
             .to_zoned(TimeZone::UTC)
             .unwrap();
-        let mut events = schedule.after(&starting_date);
+        let mut events = schedule.after(starting_date);
         assert_eq!(
             date(2017, 2, 25)
                 .at(23, 0, 0, 0)
@@ -365,7 +365,7 @@ mod tests {
             .at(14, 29, 36, 0)
             .to_zoned(TimeZone::UTC)
             .unwrap();
-        let mut events = schedule.after(&starting_date);
+        let mut events = schedule.after(starting_date);
 
         assert_eq!(
             date(2018, 1, 1)
@@ -525,13 +525,13 @@ mod tests {
             .at(0, 0, 59, 0)
             .to_zoned(TimeZone::UTC)
             .unwrap();
-        let next_time_1 = schedule.after(&start_time_1).next().unwrap();
+        let next_time_1 = schedule.after(start_time_1).next().unwrap();
 
         let start_time_2 = date(2017, 10, 24)
             .at(0, 1, 0, 0)
             .to_zoned(TimeZone::UTC)
             .unwrap();
-        let next_time_2 = schedule.after(&start_time_2).next().unwrap();
+        let next_time_2 = schedule.after(start_time_2).next().unwrap();
         assert_eq!(next_time_1, next_time_2);
     }
 
@@ -542,10 +542,10 @@ mod tests {
             .at(22, 30, 0, 0)
             .to_zoned(TimeZone::UTC)
             .unwrap();
-        let next_time_1 = schedule_1.after(&start_time).next().unwrap();
+        let next_time_1 = schedule_1.after(start_time.clone()).next().unwrap();
 
         let schedule_2 = "00 00 * * * * *".parse::<Schedule>().unwrap();
-        let next_time_2 = schedule_2.after(&start_time).next().unwrap();
+        let next_time_2 = schedule_2.after(start_time).next().unwrap();
         assert_eq!(next_time_1, next_time_2);
     }
 
@@ -558,7 +558,7 @@ mod tests {
             .to_zoned(schedule_tz.clone())
             .unwrap();
 
-        let mut schedule_iter = schedule.after(&dt);
+        let mut schedule_iter = schedule.after(dt);
         assert_eq!(
             date(2020, 9, 18)
                 .at(0, 0, 0, 0)
@@ -577,7 +577,7 @@ mod tests {
             .to_zoned(schedule_tz.clone())
             .unwrap();
 
-        let mut schedule_iter = schedule.after(&dt);
+        let mut schedule_iter = schedule.after(dt);
         assert_eq!(
             date(2020, 9, 18)
                 .at(0, 0, 0, 0)
@@ -596,7 +596,7 @@ mod tests {
             .to_zoned(schedule_tz.clone())
             .unwrap();
 
-        let mut schedule_iter = schedule.after(&dt);
+        let mut schedule_iter = schedule.after(dt);
         let expected_values = [
             date(2020, 1, 1)
                 .at(0, 0, 17, 0)
@@ -636,7 +636,7 @@ mod tests {
             .at(0, 0, 0, 0)
             .to_zoned(schedule_tz.clone())
             .unwrap();
-        let mut schedule_iter = schedule.after(&dt);
+        let mut schedule_iter = schedule.after(dt);
         let expected_values = [
             date(2020, 3, 1)
                 .at(0, 0, 0, 0)
@@ -668,7 +668,7 @@ mod tests {
             .at(0, 0, 0, 0)
             .to_zoned(schedule_tz.clone())
             .unwrap();
-        let mut schedule_iter = schedule.after(&dt);
+        let mut schedule_iter = schedule.after(dt);
         let expected_values = [
             date(2020, 1, 1)
                 .at(10, 0, 0, 0)
@@ -700,7 +700,7 @@ mod tests {
             .at(0, 0, 0, 0)
             .to_zoned(schedule_tz.clone())
             .unwrap();
-        let mut schedule_iter = schedule.after(&dt);
+        let mut schedule_iter = schedule.after(dt);
         let expected_values = [
             date(2020, 1, 11)
                 .at(0, 0, 0, 0)
@@ -744,7 +744,7 @@ mod tests {
             .at(0, 0, 0, 0)
             .to_zoned(schedule_tz.clone())
             .unwrap();
-        let mut schedule_iter = schedule.after(&dt);
+        let mut schedule_iter = schedule.after(dt);
         let expected_values = [
             date(2020, 2, 1)
                 .at(0, 0, 0, 0)
@@ -784,7 +784,7 @@ mod tests {
             .at(0, 0, 0, 0)
             .to_zoned(schedule_tz.clone())
             .unwrap();
-        let mut schedule_iter = schedule.after(&dt);
+        let mut schedule_iter = schedule.after(dt);
         let expected_values = [
             date(2030, 1, 1)
                 .at(0, 0, 0, 0)
@@ -808,7 +808,7 @@ mod tests {
             .at(0, 0, 0, 0)
             .to_zoned(schedule_tz.clone())
             .unwrap();
-        let mut schedule_iter = schedule.after(&dt);
+        let mut schedule_iter = schedule.after(dt);
         let expected_values = [
             date(2020, 1, 1)
                 .at(0, 21, 0, 0)
@@ -856,7 +856,7 @@ mod tests {
             .at(0, 0, 0, 0)
             .to_zoned(schedule_tz.clone())
             .unwrap();
-        let mut schedule_iter = schedule.after(&dt);
+        let mut schedule_iter = schedule.after(dt);
         let expected_values = [
             date(2020, 3, 1)
                 .at(0, 0, 0, 0)


### PR DESCRIPTION
This semver-breaking changeset makes the scheduler iterator API more idiomatic:

- Replace internal `clone`s by taking ownership. Rule: caller allocates.

- Rename converting iterator methods to `into_*`.

Consistency changes:

- `OwnedScheduleIterator::new` is no longer public. Use `Schedule::into_after` instead.

Implements #50.